### PR TITLE
Reduced memory usage

### DIFF
--- a/sphere2cube.py
+++ b/sphere2cube.py
@@ -78,9 +78,9 @@ class UnitSphere:
         self.TexturePath = texPath
         texImg = Image.open(texPath)
         print("loading %s %s" %(texPath, str(texImg.size)))
-        d = texImg.getdata()
+        # d = texImg.getdata()
 
-        self.PixelBuffer = list(d)
+        self.PixelBuffer = texImg.getdata()
         self.ImageW = texImg.size[0]
         self.ImageH = texImg.size[1]
 


### PR DESCRIPTION
当使用list转换texImg.getdata()时，会使用大量内存。改为直接使用texImg.getdata()。